### PR TITLE
lib/utils.js: changed year format from yy to yyyy

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -3,7 +3,7 @@ import convert from "color-convert";
 
 function formatDate(orig) {
   if (!orig) return;
-  return format(new Date(orig), "yy-MM-dd HH:mm:ss");
+  return format(new Date(orig), "yyyy-MM-dd HH:mm:ss");
 }
 
 function pad(num) {


### PR DESCRIPTION
This PR is a fix for issue #9 where the date was initially in the format `yy-mm-dd hh:mm:ss` and the year was changed to `yyyy` format.