### PR TITLE
Add routes for backwards compatibility

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,8 @@ function App(props: AppProps) {
           <Route path="/runs/:name" element={<Run />} />
           <Route path="/runs/:name/jobs/:job_id" element={<Job />} />
           <Route path="/queue" element={<Queue />} />
+          <Route path="/:name" element={<Run />} />
+          <Route path="/:name/:job_id" element={<Job />} />
         </Routes>
       </div>
     </div>


### PR DESCRIPTION
The original pulpito used routes like /:run/:job_id. While we prefer the more explicit routes, it'll be helpful if URLs are mostly backwards compatible.