### PR TITLE
pages/Runs/index.tsx: fixed date filter box alignment 

### DIFF
--- a/src/pages/Runs/index.tsx
+++ b/src/pages/Runs/index.tsx
@@ -125,7 +125,7 @@ export default function Runs() {
             type="date"
             size="small"
             margin="dense"
-            style={{ margin: "10px", paddingTop: "16px" }}
+            style={{ margin: "10px"}}
             onChange={onDateChange}
             defaultValue={state.date}
           />


### PR DESCRIPTION
Fixed Issue #10 
The date filter box is now aligned to other widgets.
![image](https://github.com/ceph/pulpito-ng/assets/78318301/0e5fd911-1051-4b06-bfde-6433c9c0786f)
