### PR TITLE
src/lib/paddles.ts: Add VITE_ prefix to env variables

### DIFF
--- a/src/lib/paddles.ts
+++ b/src/lib/paddles.ts
@@ -4,8 +4,7 @@ import type { UseQueryResult } from "@tanstack/react-query";
 import type { GetURLParams, Run, Job } from "./paddles.d";
 
 const PADDLES_SERVER =
-  import.meta.env.REACT_APP_PADDLES_SERVER ||
-  "https://paddles.front.sepia.ceph.com";
+  import.meta.env.VITE_PADDLES_SERVER || "https://paddles.front.sepia.ceph.com";
 
 function getURL(endpoint: string, params?: GetURLParams) {
   // Because paddles' API is clunky, we have to do extra work. If it were


### PR DESCRIPTION
This PR fixes issue #34 by adding the `VITE_` prefix to `PADDLES_SERVER` variable.