### PR TITLE
pages/Job/index.jsx: Add sanity check for started time

### DIFF
--- a/src/pages/Job/index.jsx
+++ b/src/pages/Job/index.jsx
@@ -11,6 +11,7 @@ import PlayCircleOutlineIcon from "@mui/icons-material/PlayCircleOutline";
 import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
 import HighlightOffIcon from "@mui/icons-material/HighlightOff";
 import formatDuration from "date-fns/formatDuration";
+import { isValid, parse } from "date-fns";
 import Editor from "react-simple-code-editor";
 import { highlight, languages } from "prismjs/components/prism-core";
 import "prismjs/components/prism-yaml";
@@ -43,6 +44,11 @@ function StatusIcon({ status }) {
 }
 
 function timeSince(date) {
+  const parsedDate = parse(date, "yyyy-MM-dd HH:mm:ss", new Date());
+  if (!isValid(parsedDate)) {
+    return 'N/A';
+  }
+
   let minute = 60;
   let hour   = minute * 60;
   let day    = hour   * 24;


### PR DESCRIPTION
This PR solves #26  issue https://github.com/ceph/pulpito-ng/issues/26 by adding a function to check whether a date is valid or not using `isValid` function of `date-fns` library. This function is further used in timeSince and returns N/A if the date is not valid.