### PR TITLE
Fix breakage if teuthology-api endpoint is unconfigured

### DIFF
--- a/src/components/Login/index.jsx
+++ b/src/components/Login/index.jsx
@@ -20,6 +20,8 @@ export default function Login() {
     setAnchorEl(null);
   };
 
+  if ( ! sessionQuery.isSuccess ) return null;
+
   return (
     <div>
       {sessionQuery.data?.session

--- a/src/components/Login/index.jsx
+++ b/src/components/Login/index.jsx
@@ -5,7 +5,7 @@ import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import GitHubIcon from '@mui/icons-material/GitHub';
 
-import { useLogin, useLogout, useSession, useUserData } from "../../lib/teuthologyAPI";
+import { doLogin, doLogout, useSession, useUserData } from "../../lib/teuthologyAPI";
 
 
 export default function Login() {
@@ -42,12 +42,12 @@ export default function Login() {
                 'aria-labelledby': 'basic-button',
               }}
             >
-              <MenuItem onClick={useLogout}>Logout</MenuItem>
+              <MenuItem onClick={doLogout}>Logout</MenuItem>
             </Menu>
         </div>
         : <Button 
             variant="contained" 
-            onClick={useLogin} 
+            onClick={doLogin}
             startIcon={<GitHubIcon fontSize="small" /> }
             disabled={sessionQuery.isError}
           >

--- a/src/lib/teuthologyAPI.ts
+++ b/src/lib/teuthologyAPI.ts
@@ -12,12 +12,12 @@ function getURL(relativeURL: URL|string): string {
     return new URL(relativeURL, TEUTHOLOGY_API_SERVER).toString();
 }
 
-function useLogin() {
+function doLogin() {
     const url = getURL("/login/");
     if ( url ) window.location.href = url;
 }
 
-function useLogout() {
+function doLogout() {
     const cookies = new Cookies();
     cookies.remove(GH_USER_COOKIE);
     
@@ -57,8 +57,8 @@ function useUserData(): Map<string, string> {
 }
 
 export {
-    useLogin,
-    useLogout,
+    doLogin,
+    doLogout,
     useSession,
     useUserData
 }

--- a/src/lib/teuthologyAPI.ts
+++ b/src/lib/teuthologyAPI.ts
@@ -4,24 +4,29 @@ import { Cookies } from "react-cookie";
 import type { UseQueryResult } from "@tanstack/react-query";
 
 const TEUTHOLOGY_API_SERVER = 
-    import.meta.env.VITE_TEUTHOLOGY_API || "https://teuthology-api.com";
+    import.meta.env.VITE_TEUTHOLOGY_API || "";
 const GH_USER_COOKIE = "GH_USER";
 
+function getURL(relativeURL: URL|string): string {
+    if ( ! TEUTHOLOGY_API_SERVER ) return "";
+    return new URL(relativeURL, TEUTHOLOGY_API_SERVER).toString();
+}
+
 function useLogin() {
-    const url =  new URL("/login/", TEUTHOLOGY_API_SERVER).href;
-    window.location.href = url;
+    const url = getURL("/login/");
+    if ( url ) window.location.href = url;
 }
 
 function useLogout() {
     const cookies = new Cookies();
     cookies.remove(GH_USER_COOKIE);
     
-    const url =  new URL("/logout/", TEUTHOLOGY_API_SERVER).href;
+    const url = getURL("/logout/");
     window.location.href = url;
 }
 
 function useSession(): UseQueryResult {
-    const url =  new URL("/", TEUTHOLOGY_API_SERVER).href;
+    const url = getURL("/");
     const query = useQuery({
         queryKey: ['ping-api', { url }],
         queryFn: () => (
@@ -30,6 +35,7 @@ function useSession(): UseQueryResult {
             }).then((resp) => resp.data)
         ),
         retry: 1,
+        enabled: url !== "",
     });
     return query;
 }


### PR DESCRIPTION
#52 was merged in a state where a missing `VITE_TEUTHOLOGY_API` env var would cause all routes to render as a blank white page. If the setting was present but incorrect, a broken Login button would be rendered.