### PR TITLE
paddles.d.ts: Add 'RunWithJobs' interface 

### DIFF
--- a/src/lib/paddles.d.ts
+++ b/src/lib/paddles.d.ts
@@ -64,7 +64,6 @@ export type Run = {
   name: string;
   branch: string;
   suite: string;
-  jobs: Job[];
   scheduled: string;
   user: string;
   started: string;
@@ -77,6 +76,11 @@ export type Run = {
   machine_type: string;
   status: RunStatus;
 };
+
+
+interface RunWithJobs extends Run {
+  jobs: Job[]; 
+}
 
 export type Node = {
   name: string;

--- a/src/lib/paddles.ts
+++ b/src/lib/paddles.ts
@@ -4,6 +4,7 @@ import type { UseQueryResult } from "@tanstack/react-query";
 import type { 
   GetURLParams, 
   Run, Job, 
+  RunWithJobs,
   Node, NodeJobs,
   StatsLocksResponse,
   StatsJobsResponse,
@@ -69,10 +70,10 @@ function useRuns(params: GetURLParams): UseQueryResult<Run[]> {
   return query;
 }
 
-function useRun(name: string): UseQueryResult<Run> {
+function useRun(name: string): UseQueryResult<RunWithJobs> {
   const url = getURL(`/runs/${name}/`);
-  const query = useQuery<Run, Error>(["run", { url }], {
-    select: (data: Run) => {
+  const query = useQuery<RunWithJobs, Error>(["run", { url }], {
+    select: (data: RunWithJobs) => {
       data.jobs.forEach((item) => {
         item.id = item.job_id + "";
       });

--- a/src/pages/Run/index.tsx
+++ b/src/pages/Run/index.tsx
@@ -6,7 +6,7 @@ import Typography from "@mui/material/Typography";
 import { format } from "date-fns";
 import { Helmet } from "react-helmet";
 
-import type { Run as Run_, RunParams } from "../../lib/paddles.d";
+import type { RunWithJobs as Run_, RunParams } from "../../lib/paddles.d";
 
 import { useRun } from "../../lib/paddles";
 import JobList from "../../components/JobList";


### PR DESCRIPTION
Do not process jobs when loading RunList.
This might improve the load time of run page.

   Only need to process jobs for 'useRun' query
for JobList.


