### PR TITLE
Add table cell border (and other table UI improvements)

### DIFF
--- a/src/components/JobList/index.tsx
+++ b/src/components/JobList/index.tsx
@@ -39,7 +39,7 @@ const columns: MRT_ColumnDef<Job>[] = [
         <div>
           {log_url? (
             <IconLink to={dirName(log_url)}>
-              <DescriptionIcon fontSize="small" />
+              <DescriptionIcon fontSize="small" style={{marginLeft: '5px'}} />
             </IconLink>
           ) : null}
           {sentry_url ? (
@@ -47,7 +47,7 @@ const columns: MRT_ColumnDef<Job>[] = [
               <img
                 src={`${sentryIcon}`}
                 alt="Sentry icon"
-                style={{height: '20px', width: '20px'}}
+                style={{height: '20px', width: '20px', marginLeft: '5px'}}
               />
             </IconLink>
           ) : null}

--- a/src/components/RunList/index.tsx
+++ b/src/components/RunList/index.tsx
@@ -33,6 +33,20 @@ const NON_FILTER_PARAMS = [
 
 const columns: MRT_ColumnDef<Run>[] = [
   {
+    accessorKey: "name",
+    header: "link",
+    maxSize: 12,
+    enableColumnFilter: false,
+    enableColumnActions: false,
+    Cell: ({ row }) => {
+      return (
+        <IconLink to={`/runs/${row.original.name}`}>
+          <OpenInNewIcon fontSize="small" style={{marginLeft: "5px"}} />
+        </IconLink>
+      );
+    },
+  },
+  {
     header: "status",
     accessorKey: "status",
     filterVariant: "select",
@@ -40,25 +54,15 @@ const columns: MRT_ColumnDef<Run>[] = [
       return row.original.status.replace("finished ", "");
     },
     filterSelectOptions: Object.values(RunStatuses),
+    size: 40,
+    enableColumnActions: false,
   },
   {
     accessorKey: "user",
     header: "user",
-    size: 60,
+    maxSize: 45,
     enableColumnFilter: false,
-  },
-  {
-    accessorKey: "name",
-    header: "link",
-    size: 30,
-    enableColumnFilter: false,
-    Cell: ({ row }) => {
-      return (
-        <IconLink to={`/runs/${row.original.name}`}>
-          <OpenInNewIcon fontSize="small" />
-        </IconLink>
-      );
-    },
+    enableColumnActions: false,
   },
   {
     id: "scheduled",
@@ -66,7 +70,11 @@ const columns: MRT_ColumnDef<Run>[] = [
     accessorFn: (row: Run) => formatDate(row.scheduled),
     filterVariant: 'date',
     sortingFn: "datetime",
-    size: 125,
+    Cell: ({ row }) => {
+      const date_: string[] = row.original.scheduled.split(" ");
+      return <div> {date_[0]} <br /> {date_[1]} </div>
+    },
+    size: 50,
   },
   {
     id: "started",
@@ -95,7 +103,7 @@ const columns: MRT_ColumnDef<Run>[] = [
     },
     enableColumnFilter: false,
     sortingFn: "datetime",
-    size: 70,
+    size: 30,
   },
   {
     accessorKey: "suite",
@@ -115,8 +123,10 @@ const columns: MRT_ColumnDef<Run>[] = [
   {
     accessorKey: "sha1",
     header: "hash",
-    size: 30,
-    maxSize: 50,
+    maxSize: 30,
+    Cell: ({ row }) => {
+      return row.original.sha1.slice(0, 8);
+    },
   },
   {
     accessorKey: "results.queued",
@@ -133,25 +143,25 @@ const columns: MRT_ColumnDef<Run>[] = [
   {
     accessorKey: "results.fail",
     header: "fail",
-    size: 40,
+    size: 30,
     enableColumnFilter: false,
   },
   {
     accessorKey: "results.dead",
     header: "dead",
-    size: 40,
+    size: 30,
     enableColumnFilter: false,
   },
   {
     accessorKey: "results.running",
     header: "running",
-    size: 40,
+    size: 30,
     enableColumnFilter: false,
   },
   {
     accessorKey: "results.waiting",
     header: "waiting",
-    size: 40,
+    size: 30,
     enableColumnFilter: false,
   },
 ];

--- a/src/lib/table.ts
+++ b/src/lib/table.ts
@@ -38,6 +38,7 @@ export default function useDefaultTableOptions<TData extends MRT_RowData>(): Par
           paddingRight: 0,
           paddingTop: '5px',
           color: "black",
+          borderLeft: "0.3px solid " + theme.palette.background.default,
         },
         'tr td:has(svg)': {
           padding: 0,


### PR DESCRIPTION
This PR:
1. Adds border to table cells
2. disable column action buttons (three vertical dots) from columns "link", "status", and "user". This makes some space in header column of the table for displaying text. Its only disabled for these fields because column actions can be useful to hide a column from the table and these are essential columns which probably don't need to be removed from view. 
3. Link column is moved to left most to give better collected view of information.
4. "scheduled" column is edited so date and time show up in different lines (like in pulpito). Helps to reduce column width. 
5. Only show 8 letters of "hash" column. Original pulpito has a similar view. Helps to reduce column width. 
6. Make all status columns at the end ("fail", "pass", etc) of same width to bring uniformity in the view. 

Before: 
<img width="1442" alt="image" src="https://github.com/user-attachments/assets/87e05a73-4804-46db-b335-be0be58ce402">


After:
<img width="1465" alt="image" src="https://github.com/user-attachments/assets/434e7b0a-049c-41c9-a58f-91d862e2518a">
