### PR TITLE
Show JobHistory on Job Page

### DIFF
--- a/src/components/JobHistory/index.jsx
+++ b/src/components/JobHistory/index.jsx
@@ -1,0 +1,23 @@
+import JobList from "../JobList";
+import { useJobHistory } from "../../lib/paddles";
+import { Button, Typography, Box } from "@mui/material";
+
+
+const pageSize = 25;
+
+export default function JobHistory({description}) {
+  if (!description) {
+    return null;
+  }
+  
+  const jobHistoryQuery = useJobHistory(description, pageSize);
+
+  return (
+    <Box sx={{ padding: '0px 8px' }}>
+      <Typography variant="body1" margin={"10px 0px"}> 
+        Past {pageSize} jobs with same description:
+      </Typography>
+      <JobList query={jobHistoryQuery} sortMode="time" />
+    </Box>
+  );
+}

--- a/src/components/JobList/index.tsx
+++ b/src/components/JobList/index.tsx
@@ -14,7 +14,7 @@ import { type Theme } from "@mui/material/styles";
 import { formatDate, formatDuration } from "../../lib/utils";
 import IconLink from "../../components/IconLink";
 import Link from "../../components/Link";
-import type { Job, NodeJobs, Run } from "../../lib/paddles.d";
+import type { Job, JobList, Run } from "../../lib/paddles.d";
 import { dirName } from "../../lib/utils";
 import useDefaultTableOptions from "../../lib/table";
 
@@ -220,7 +220,7 @@ function JobDetailPanel(props: JobDetailPanelProps): ReactNode {
 };
 
 type JobListProps = {
-  query: UseQueryResult<Run> | UseQueryResult<NodeJobs>;
+  query: UseQueryResult<Run> | UseQueryResult<JobList>;
   sortMode?: "time" | "id";
 }
 

--- a/src/lib/paddles.d.ts
+++ b/src/lib/paddles.d.ts
@@ -95,7 +95,7 @@ export type Node = {
   machine_type: string;
 };
 
-export type NodeJobs = {
+export type JobList = {
   jobs?: Job[];
 }
 

--- a/src/pages/Job/index.jsx
+++ b/src/pages/Job/index.jsx
@@ -5,6 +5,7 @@ import Typography from "@mui/material/Typography";
 import Accordion from "@mui/material/Accordion";
 import AccordionSummary from "@mui/material/AccordionSummary";
 import AccordionDetails from "@mui/material/AccordionDetails";
+import Button from "@mui/material/Button";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ScheduleIcon from "@mui/icons-material/Schedule";
 import PlayCircleOutlineIcon from "@mui/icons-material/PlayCircleOutline";
@@ -21,6 +22,8 @@ import Link from "../../components/Link";
 import CodeBlock from "../../components/CodeBlock";
 import { useJob } from "../../lib/paddles";
 import { getDuration, dirName } from "../../lib/utils";
+import JobHistory from "../../components/JobHistory";
+import { useState } from "react";
 
 function StatusIcon({ status }) {
   const theme = useTheme();
@@ -155,6 +158,7 @@ function JobDetails({ query }) {
 export default function Job() {
   const { name, job_id } = useParams();
   const query = useJob(name, job_id);
+  const [showJobHistory, toggleShowJobHistory] = useState(false);
   return (
     <Grid container spacing={2}>
       <Helmet>
@@ -173,6 +177,15 @@ export default function Job() {
             <JobDetails query={query} />
           </AccordionDetails>
         </Accordion>
+        <Button variant={"text"} sx={{"marginTop": "10px"}}
+                onClick={() => toggleShowJobHistory(!showJobHistory)}>
+          {showJobHistory ? "Hide": "Show"} history
+        </Button>
+        { showJobHistory ?
+            (query.data?.description ? <JobHistory description={query.data.description} /> : null)
+            :null
+        }
+        
       </Grid>
     </Grid>
   );


### PR DESCRIPTION
Display last 25 job runs of that description.
The reason why the history is shown after a button click (and hidden by default) is to avoid an extra call to paddles if user is not looking for job-history information and also to avoid information overload for users. 

Output example:
<img width="1472" alt="image" src="https://github.com/user-attachments/assets/df604c9c-ee49-4835-8252-972c0d943dd4">
