### PR TITLE
Improve rendering of multi-line job failure reasons

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -10,4 +10,5 @@ body {
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
     monospace;
+  white-space: pre-line;
 }


### PR DESCRIPTION
Modify css code to preserve white space so a multi-line failure reason retains its formatting

See https://github.com/ceph/ceph/pull/65067