### PR TITLE
Create OCP-friendly deployment

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,0 +1,18 @@
+# ---- build stage ----
+FROM node:18-alpine AS build
+WORKDIR /app
+
+# (optional) allow overriding paddles URL at build time
+ARG REACT_APP_PADDLES_SERVER
+ENV REACT_APP_PADDLES_SERVER=$REACT_APP_PADDLES_SERVER
+
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+RUN npm run build
+
+# ---- runtime stage ----
+FROM nginxinc/nginx-unprivileged:stable-alpine
+COPY --from=build /app/build /usr/share/nginx/html
+COPY openshift/nginx/default.conf /etc/nginx/conf.d/default.conf

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ In [teuthology's docker-compose](https://github.com/ceph/teuthology/blob/main/do
     ports:
       - 8081:8081
 ```
-[recommended] For developement purposes:
+[recommended] For development purposes:
 Add the following to `pulpito-ng` container:
 
 ```
@@ -51,4 +51,68 @@ pulpito-ng:
     volumes:
       - ../../../pulpito-ng:/app/:rw
       - /app/node_modules
+```
+
+## Deploying in OpenShift
+
+``Dockerfile.ocp`` and the files under ``openshift/`` are files used to deploy pulpito-ng in OpenShift.
+
+You may wish to change the number of replicas in ``openshift/pulpito-ng-deploy.yaml`` depending on how many worker nodes you have.
+
+To deploy:
+
+Create a new project (if necessary)
+```
+oc new-project pulpito
+```
+
+Create the Image Stream
+```
+oc -n pulpito apply -f openshift/pulpito-ng-imagestream.yaml
+```
+
+Modify the Build Config if necessary and start the build
+```
+oc -n pulpito apply -f openshift/pulpito-ng-build.yaml
+```
+
+Define the paddles URL
+```
+oc -n pulpito set env bc/pulpito-ng \
+  REACT_APP_PADDLES_SERVER=http://paddles.example.com
+```
+
+Start the build
+```
+oc -n pulpito start-build pulpito-ng --follow
+```
+
+Deploy!
+```
+oc -n pulpito apply -f openshift/pulpito-ng-deploy.yaml
+
+oc -n pulpito get route pulpito-ng
+```
+
+### Deploying code changes in OpenShift
+
+If you just want to deploy the latest code in ``main`` (and your Build Config in ``openshift/pulpito-ng-build.yaml`` doesn't have a different branch defined),
+
+(Note, the ``--follow`` will likely timout if you do not wait for the first build from above to finish)
+```
+oc -n pulpito start-build pulpito-ng --follow
+```
+
+If you wish to deploy code from a different pulpito-ng.git branch,
+
+Start a one-off build of the branch.  The deployment will automatically roll this out.
+```
+oc -n pulpito start-build pulpito-ng --follow --commit=<branch-name>
+```
+
+To make the deployment use this branch permanently, modify ``spec.source.git.ref:`` in ``openshift/pulpito-ng-build.yaml``, and build it:
+```
+oc -n pulpito apply -f openshift/pulpito-ng-build.yaml
+
+oc -n pulpito start-build pulpito-ng --follow
 ```

--- a/openshift/nginx/default.conf
+++ b/openshift/nginx/default.conf
@@ -1,0 +1,13 @@
+# Note: This file is intended for OCP-based deployments
+server {
+  listen 8080;
+  server_name _;
+
+  root /usr/share/nginx/html;
+  index index.html;
+
+  # SPA routes: anything that isn't a real file falls back to index.html
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+}

--- a/openshift/pulpito-ng-build.yaml
+++ b/openshift/pulpito-ng-build.yaml
@@ -1,0 +1,21 @@
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  name: pulpito-ng
+spec:
+  runPolicy: Serial
+  source:
+    type: Git
+    git:
+      uri: https://github.com/ceph/pulpito-ng
+      ref: main
+  strategy:
+    type: Docker
+    dockerStrategy:
+      dockerfilePath: Dockerfile.ocp
+  output:
+    to:
+      kind: ImageStreamTag
+      name: pulpito-ng:latest
+  triggers:
+  - type: ConfigChange

--- a/openshift/pulpito-ng-deploy.yaml
+++ b/openshift/pulpito-ng-deploy.yaml
@@ -1,0 +1,78 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pulpito-ng
+  labels:
+    app: pulpito-ng
+  annotations:
+    # When the BuildConfig updates the ImageStreamTag pulpito-ng:latest,
+    # automatically roll out the Deployment to the new image.
+    image.openshift.io/triggers: >-
+      [{"from":{"kind":"ImageStreamTag","name":"pulpito-ng:latest"},
+        "fieldPath":"spec.template.spec.containers[?(@.name==\"pulpito-ng\")].image"}]
+spec:
+  replicas: 2
+  revisionHistoryLimit: 10
+  progressDeadlineSeconds: 300
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: pulpito-ng
+  template:
+    metadata:
+      labels:
+        app: pulpito-ng
+    spec:
+      containers:
+      - name: pulpito-ng
+        # This gets rewritten by the ImageStream trigger above.
+        image: pulpito-ng:latest
+        imagePullPolicy: Always
+        ports:
+        - name: http
+          containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /
+            port: http
+          initialDelaySeconds: 3
+          timeoutSeconds: 2
+          periodSeconds: 5
+          failureThreshold: 6
+        livenessProbe:
+          httpGet:
+            path: /
+            port: http
+          initialDelaySeconds: 10
+          timeoutSeconds: 2
+          periodSeconds: 10
+          failureThreshold: 3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pulpito-ng
+  labels:
+    app: pulpito-ng
+spec:
+  selector:
+    app: pulpito-ng
+  ports:
+  - name: http
+    port: 8080
+    targetPort: http
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: pulpito-ng
+spec:
+  to:
+    kind: Service
+    name: pulpito-ng
+  port:
+    targetPort: http

--- a/openshift/pulpito-ng-imagestream.yaml
+++ b/openshift/pulpito-ng-imagestream.yaml
@@ -1,0 +1,4 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: pulpito-ng


### PR DESCRIPTION
pulpito-ng does not run correctly on OpenShift out of the box. OpenShift runs containers as non-root and enforces Security Context Constraints, which causes the existing Node-based runtime to fail at startup due to filesystem ownership changes.

This change switches pulpito-ng to a safer deployment model:

- Build the React UI as static files during image build
- Serve the UI with an unprivileged nginx runtime
- Add nginx fallback routing so deep links (e.g. /runs/<id>) work
- Avoid any runtime chown or root assumptions

These files make it possible to build and deploy pulpito-ng directly from git on OpenShift without requiring privileged permissions or runtime workarounds.